### PR TITLE
build(npm): use package.json files field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.babelrc
-.editorconfig
-.esdoc.json
-.travis.yml
-yarn.lock
-node_modules/
-src/
-types/*
-!types/index.d.ts

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Danger plugin to link JIRA issue in pull request",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "dist",
+    "types/index.d.ts"
+  ],
   "scripts": {
     "precommit": "lint-staged",
     "commit": "git-cz",


### PR DESCRIPTION
This is simpler than using .npmignore.