### PR TITLE
feat($options): Adds message format function to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ jiraIssue({
   key: 'JIRA',
   url: 'https://myjira.atlassian.net/browse',
   emoji: ':paperclip:',
+  format(emoji, jiraUrls) { // Optional Formatter
+    return 'Some Custom Message'; 
+  }
 })
 ```
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -110,4 +110,19 @@ describe("jiraIssue()", () => {
       ':link: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/DEF-456">DEF-456</a>'
     );
   });
+  it("supports a custom format function", () => {
+    global.danger = {
+      github: { pr: { title: "[ABC-123][DEF-456] Change some things" } }
+    };
+    jiraIssue({
+      format: (emoji, jiraUrls) => {
+        return `${emoji} JIRA Tickets: ${jiraUrls.join(", ")}`;
+      },
+      key: ["ABC", "DEF"],
+      url: "https://jira.net/browse"
+    });
+    expect(global.message).toHaveBeenCalledWith(
+      ':link: JIRA Tickets: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/DEF-456">DEF-456</a>'
+    );
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,13 @@ export interface Options {
    * Defaults to `':link:'`.
    */
   emoji?: string;
+  /**
+   * A format function to format the message
+   * @param {string} emoji
+   * @param {string[]} jiraUrls
+   * @returns {string}
+   */
+  format?: (emoji: string, jiraUrls: string[]) => string;
 }
 
 const link = (href: string, text: string): string =>
@@ -53,10 +60,16 @@ export default function jiraIssue(options: Options) {
     jiraIssues.push(match[0]);
   }
   if (jiraIssues.length > 0) {
-    const jiraUrls = jiraIssues
-      .map(issue => link(resolve(ensureUrlEndsWithSlash(url), issue), issue))
-      .join(", ");
-    message(`${emoji} ${jiraUrls}`);
+    const jiraUrls = jiraIssues.map(issue =>
+      link(resolve(ensureUrlEndsWithSlash(url), issue), issue)
+    );
+
+    // use custom formatter, or default
+    if (options.format) {
+      message(options.format(emoji, jiraUrls));
+    } else {
+      message(`${emoji} ${jiraUrls.join(", ")}`);
+    }
   } else {
     warn(`Please add the JIRA issue key to the PR title (e.g. ${key}-123)`);
   }


### PR DESCRIPTION
We wanted to customize the message in danger with a prefix and saw that we couldn't modify the message format. This PR -

* Adds a message format function to the options object that is passed the JIRA URls array and the
selected emoji. The function can return a custom string to format the danger message.

* Adds a test 

* Updates the example in the readme