### PR TITLE
feat: simplify plugin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,12 @@ At a glance:
 
 ```js
 // dangerfile.js
-import jiraIssue from "danger-plugin-jira-issue";
+import jiraIssue from 'danger-plugin-jira-issue'
 
 jiraIssue({
-  key: "JIRA",
-  url: "https://myjira.atlassian.net/browse",
-  emoji: ":paperclip:",
-  format(emoji, jiraUrls) {
-    // Optional Formatter
-    return "Some Custom Message";
-  },
-  location: "title" // Optional location, either 'title' or 'branch'
-});
+  key: 'JIRA',
+  url: 'https://myjira.atlassian.net/browse',
+})
 ```
 
 With JIRA-123 in the PR title, Danger will comment with:
@@ -55,12 +49,24 @@ If you work with multiple JIRA project boards, you can supply multiple project k
 
 ```js
 jiraIssue({
-  key: ["ABC", "DEF"],
-  url: "https://myjira.atlassian.net/browse"
-});
+  key: ['ABC', 'DEF'],
+  url: 'https://myjira.atlassian.net/browse',
+})
 ```
 
 This plugin will recognize issues starting with those keys (e.g. `ABC-123` and `DEF-234`).
+
+You can also supply an optional `format` option, which is a function that receives an array of formatted JIRA URLs and returns a string.
+
+```js
+jiraIssue({
+  key: 'ABC',
+  url: 'https://myjira.atlassian.net/browse',
+  format(urls) {
+    return `Check out these awesome tickets: ${urls.join(', ')}`
+  },
+})
+```
 
 ## Changelog
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,138 +2,163 @@ import jiraIssue from './'
 
 declare const global: any
 
-describe('jiraIssue()', () => {
-  beforeEach(() => {
-    global.warn = jest.fn()
-    global.message = jest.fn()
-  })
-  afterEach(() => {
-    global.danger = undefined
-    global.warn = undefined
-    global.message = undefined
-  })
-  it('throws when supplied invalid configuration', () => {
-    const anyJira = jiraIssue as any
-    expect(() => anyJira()).toThrow()
-    expect(() => jiraIssue({} as any)).toThrow()
-    expect(() => jiraIssue({ key: 'ABC' } as any)).toThrow()
-    expect(() => jiraIssue({ url: 'https://jira.net/browse' } as any)).toThrow()
-  })
-  it('warns when PR title is missing JIRA issue key', () => {
-    global.danger = { github: { pr: { title: 'Change some things' } } }
-    jiraIssue({
-      key: 'ABC',
-      url: 'https://jira.net/browse',
-    })
-    expect(global.warn).toHaveBeenCalledWith(
-      'Please add the JIRA issue key to the PR title (e.g. ABC-123)'
-    )
-  })
-  it('adds the JIRA issue link to the messages table', () => {
-    global.danger = {
-      github: { pr: { title: '[ABC-808] Change some things' } },
-    }
-    jiraIssue({
-      key: 'ABC',
-      url: 'https://jira.net/browse',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':link: <a href="https://jira.net/browse/ABC-808">ABC-808</a>'
-    )
-  })
-  it('properly concatenates URL parts (trailing slash in url)', () => {
-    global.danger = {
-      github: { pr: { title: '[ABC-808] Change some things' } },
-    }
-    jiraIssue({
-      key: 'ABC',
-      url: 'https://jira.net/browse/',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':link: <a href="https://jira.net/browse/ABC-808">ABC-808</a>'
-    )
-  })
-  it('matches JIRA issue anywhere in title', () => {
-    global.danger = { github: { pr: { title: 'My changes - ABC-123' } } }
-    jiraIssue({
-      key: 'ABC',
-      url: 'https://jira.net/browse',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':link: <a href="https://jira.net/browse/ABC-123">ABC-123</a>'
-    )
-  })
-  it('does not match lowercase JIRA key in PR title', () => {
-    global.danger = {
-      github: { pr: { title: '[abc-808] Change some things' } },
-    }
-    jiraIssue({
-      key: 'ABC',
-      url: 'https://jira.net/browse',
-    })
-    expect(global.warn).toHaveBeenCalled()
-  })
-  it('honors custom emoji configuration', () => {
-    global.danger = { github: { pr: { title: '(ABC-123) Change stuff' } } }
-    jiraIssue({
-      emoji: ':paperclip:',
-      key: 'ABC',
-      url: 'https://jira.net/browse',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':paperclip: <a href="https://jira.net/browse/ABC-123">ABC-123</a>'
-    )
-  })
-  it('supports multiple JIRA keys in PR title', () => {
-    global.danger = {
-      github: { pr: { title: '[ABC-123][ABC-456] Change some things' } },
-    }
-    jiraIssue({
-      key: 'ABC',
-      url: 'https://jira.net/browse',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':link: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/ABC-456">ABC-456</a>'
-    )
-  })
-  it('supports multiple JIRA boards in PR title', () => {
-    global.danger = {
-      github: { pr: { title: '[ABC-123][DEF-456] Change some things' } },
-    }
-    jiraIssue({
-      key: ['ABC', 'DEF'],
-      url: 'https://jira.net/browse',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':link: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/DEF-456">DEF-456</a>'
-    )
-  })
-  it('supports a custom format function', () => {
-    global.danger = {
-      github: { pr: { title: '[ABC-123][DEF-456] Change some things' } },
-    }
-    jiraIssue({
-      format: (emoji, jiraUrls) => {
-        return `${emoji} JIRA Tickets: ${jiraUrls.join(', ')}`
-      },
-      key: ['ABC', 'DEF'],
-      url: 'https://jira.net/browse',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':link: JIRA Tickets: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/DEF-456">DEF-456</a>'
-    )
-  })
-  it('supports JIRA key in the git branch', () => {
-    global.danger = {
-      github: { pr: { head: { ref: 'ABC-808/some-things' } } },
-    }
-    jiraIssue({
-      key: 'ABC',
-      location: 'branch',
-      url: 'https://jira.net/browse',
-    })
-    expect(global.message).toHaveBeenCalledWith(
-      ':link: <a href="https://jira.net/browse/ABC-808">ABC-808</a>'
-    )
-  })
+beforeEach(() => {
+  global.warn = jest.fn()
+  global.message = jest.fn()
 })
+
+afterEach(() => {
+  global.danger = undefined
+  global.warn = undefined
+  global.message = undefined
+})
+
+test('throws when supplied invalid configuration', () => {
+  const anyJira = jiraIssue as any
+  expect(() => anyJira()).toThrow()
+  expect(() => jiraIssue({} as any)).toThrow()
+  expect(() => jiraIssue({ key: 'ABC' } as any)).toThrow()
+  expect(() => jiraIssue({ url: 'https://jira.net/browse' } as any)).toThrow()
+})
+
+test('warns when PR title is missing JIRA issue key', () => {
+  global.danger = createDangerState({ title: 'Change some things' })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse',
+  })
+  expect(global.warn).toHaveBeenCalledWith(
+    'No JIRA keys found in the PR title, branch name, or commit messages (e.g. ABC-123).'
+  )
+})
+
+test('adds the JIRA issue link to the messages table', () => {
+  global.danger = createDangerState({ title: '[ABC-808] Change some things' })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-808">ABC-808</a>'
+  )
+})
+
+test('properly concatenates URL parts (trailing slash in url)', () => {
+  global.danger = createDangerState({ title: '[ABC-808] Change some things' })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse/',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-808">ABC-808</a>'
+  )
+})
+
+test('matches JIRA issue anywhere in title', () => {
+  global.danger = createDangerState({ title: 'My changes - ABC-123' })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-123">ABC-123</a>'
+  )
+})
+
+test('matches lowercase JIRA key in PR title', () => {
+  global.danger = createDangerState({ title: '[abc-808] Change some things' })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-808">ABC-808</a>'
+  )
+})
+
+test('supports multiple JIRA keys in PR title', () => {
+  global.danger = createDangerState({
+    title: '[ABC-123][ABC-456] Change some things',
+  })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/ABC-456">ABC-456</a>'
+  )
+})
+
+test('supports multiple JIRA boards in PR title', () => {
+  global.danger = createDangerState({
+    title: '[ABC-123][DEF-456] Change some things',
+  })
+  jiraIssue({
+    key: ['ABC', 'DEF'],
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/DEF-456">DEF-456</a>'
+  )
+})
+
+test('supports a custom format function', () => {
+  global.danger = createDangerState({
+    title: '[ABC-123][DEF-456] Change some things',
+  })
+  jiraIssue({
+    format(jiraUrls) {
+      return `JIRA Tickets: ${jiraUrls.join(', ')}`
+    },
+    key: ['ABC', 'DEF'],
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    'JIRA Tickets: <a href="https://jira.net/browse/ABC-123">ABC-123</a>, <a href="https://jira.net/browse/DEF-456">DEF-456</a>'
+  )
+})
+
+test('supports JIRA key in the git branch', () => {
+  global.danger = createDangerState({ branchName: 'ABC-808/some-things' })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-808">ABC-808</a>'
+  )
+})
+
+test('only reports one unique URL if found in multiple locations', () => {
+  global.danger = createDangerState({
+    title: '[ABC-100] Some thing',
+    branchName: 'abc-100/make-some-thing',
+  })
+  jiraIssue({
+    key: 'ABC',
+    url: 'https://jira.net/browse',
+  })
+  expect(global.message).toHaveBeenCalledWith(
+    ':link: <a href="https://jira.net/browse/ABC-100">ABC-100</a>'
+  )
+})
+
+/** Helper function help set up Danger PR state needed by this plugin. */
+function createDangerState({
+  title = '',
+  branchName = '',
+}: {
+  title?: string
+  branchName?: string
+}): any {
+  return {
+    github: {
+      pr: {
+        title,
+        head: {
+          ref: branchName,
+        },
+      },
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,35 +9,22 @@ export interface Options {
   /** The JIRA instance issue base URL (e.g. https://jira.atlassian.com/browse/). */
   url: string
   /**
-   * The emoji to display with the JIRA issue link.
-   * See the possible emoji values, listed as keys in the
-   * [GitHub API `/emojis` response](https://api.github.com/emojis).
-   * Defaults to `':link:'`.
-   */
-  emoji?: string
-  /**
    * A format function to format the message
-   * @param {string} emoji
    * @param {string[]} jiraUrls
    * @returns {string}
    */
-  format?: (emoji: string, jiraUrls: string[]) => string
-  /**
-   * The location of the JIRA issue, either the PR title, or the git branch
-   * Defaults to `title`
-   */
-  location?: 'title' | 'branch'
+  format?: (jiraUrls: string[]) => string
 }
 
-const link = (href: string, text: string): string =>
-  `<a href="${href}">${text}</a>`
-
-const ensureUrlEndsWithSlash = (url: string) => {
-  if (!url.endsWith('/')) {
-    return url.concat('/')
-  }
-  return url
+function link(href: string, text: string): string {
+  return `<a href="${href}">${text}</a>`
 }
+
+function ensureUrlEndsWithSlash(url: string): string {
+  return url.endsWith('/') ? url : url.concat('/')
+}
+
+const defaultFormat = (urls: string[]) => `:link: ${urls.join(', ')}`
 
 /**
  * A Danger plugin to add a JIRA issue link to the Danger pull request comment.
@@ -45,9 +32,9 @@ const ensureUrlEndsWithSlash = (url: string) => {
  * then Danger will comment with a warning on the pull request asking the developer
  * to include the JIRA issue identifier in the pull request title.
  */
-export default function jiraIssue(options: Options) {
-  const { key = '', url = '', emoji = ':link:', location = 'title' } =
-    options || {}
+export default function jiraIssue(
+  { key, url, format = defaultFormat }: Options = {} as Options
+) {
   if (!url) {
     throw Error(`'url' missing - must supply JIRA installation URL`)
   }
@@ -55,48 +42,39 @@ export default function jiraIssue(options: Options) {
     throw Error(`'key' missing - must supply JIRA issue key`)
   }
 
+  function findMatches(property: string): string[] {
+    const issues: string[] = []
+
+    let match = jiraKeyRegex.exec(property)
+    while (match !== null) {
+      issues.push(match[0].toLowerCase())
+      match = jiraKeyRegex.exec(property)
+    }
+
+    return issues
+  }
+
   // Support multiple JIRA projects.
   const keys = Array.isArray(key) ? `(${key.join('|')})` : key
 
-  const jiraKeyRegex = new RegExp(`(${keys}-[0-9]+)`, 'g')
-  let match
-  const jiraIssues = []
-  // tslint:disable-next-line:no-conditional-assignment
-  let jiraLocation
-  switch (location) {
-    case 'title': {
-      jiraLocation = danger.github.pr.title
-      break
-    }
-    case 'branch': {
-      jiraLocation = danger.github.pr.head.ref
-      break
-    }
-    default: {
-      throw Error(
-        `Invalid value for 'location', must be either "title" or "branch"`
-      )
-    }
-  }
-  match = jiraKeyRegex.exec(jiraLocation)
-  while (match != null) {
-    jiraIssues.push(match[0])
-    match = jiraKeyRegex.exec(jiraLocation)
-  }
-  if (jiraIssues.length > 0) {
-    const jiraUrls = jiraIssues.map(issue =>
-      link(resolve(ensureUrlEndsWithSlash(url), issue), issue)
-    )
+  const jiraKeyRegex = new RegExp(`(${keys}-[0-9]+)`, 'gi')
 
-    // use custom formatter, or default
-    if (options.format) {
-      message(options.format(emoji, jiraUrls))
-    } else {
-      message(`${emoji} ${jiraUrls.join(', ')}`)
-    }
+  const allIssues = new Set([
+    ...findMatches(danger.github.pr.title),
+    ...findMatches(danger.github.pr.head.ref),
+  ])
+
+  if (allIssues.size > 0) {
+    // URL must end with a slash before attempting to fully resolve the JIRA URL.
+    url = ensureUrlEndsWithSlash(url)
+    const jiraUrls = Array.from(allIssues).map(issue => {
+      const formattedIssue = issue.toUpperCase()
+      const resolvedUrl = resolve(url, formattedIssue)
+      return link(resolvedUrl, formattedIssue)
+    })
+    message(format(jiraUrls))
   } else {
-    warn(
-      `Please add the JIRA issue key to the PR ${location} (e.g. ${key}-123)`
-    )
+    const warningMessage = `No JIRA keys found in the PR title, branch name, or commit messages (e.g. ${key}-123).`
+    warn(warningMessage)
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "dist",
+    "downlevelIteration": true,
     "lib": ["es5", "es2015"],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
Resolves #45

BREAKING CHANGE: This removes some options and has some modified behavior.

* automatically checks for JIRA keys in the PR title and branch name (no config needed)
* only reports unique JIRA keys (if the same one is found in the PR title and branch, only report that once)
* remove `emoji` and `location` options
* simplify `format()` option signature

TODO:

- [ ] check for JIRA keys in the commit message titles