### PR TITLE
Only add one example JIRA key to warning

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,6 +29,16 @@ describe('jiraIssue()', () => {
       'Please add the JIRA issue key to the PR title (e.g. ABC-123)'
     )
   })
+  it('only adds one example key to warning', () => {
+    global.danger = { github: { pr: { title: 'Change some things' } } }
+    jiraIssue({
+      key: ['ABC', 'DEF'],
+      url: 'https://jira.net/browse',
+    })
+    expect(global.warn).toHaveBeenCalledWith(
+      'Please add the JIRA issue key to the PR title (e.g. ABC-123)'
+    )
+  })
   it('adds the JIRA issue link to the messages table', () => {
     global.danger = {
       github: { pr: { title: '[ABC-808] Change some things' } },

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,8 +95,9 @@ export default function jiraIssue(options: Options) {
       message(`${emoji} ${jiraUrls.join(', ')}`)
     }
   } else {
+    const firstKey = Array.isArray(key) ? key[0] : key
     warn(
-      `Please add the JIRA issue key to the PR ${location} (e.g. ${key}-123)`
+      `Please add the JIRA issue key to the PR ${location} (e.g. ${firstKey}-123)`
     )
   }
 }


### PR DESCRIPTION
We have a lot of keys so right now its spitting out like "e.g. ABC,DEF,XYZ,KEY-123" which is confusing.